### PR TITLE
Bug fix : AzureMlTrain cutting off data of first column in csv

### DIFF
--- a/mlsriracha/plugins/azureml/train.py
+++ b/mlsriracha/plugins/azureml/train.py
@@ -66,7 +66,7 @@ class AzureMlTrain(TrainInterface):
         if channel in data_directories.keys():
             azure_mount_file = os.environ.get(data_directories[channel])
             print(f'azure_mount_file={azure_mount_file}')
-            data = pd.read_csv(azure_mount_file, index_col=0)
+            data = pd.read_csv(azure_mount_file)
             return data
 
         else:


### PR DESCRIPTION
AzureMlTrain.input_as_dataframe uses first column as index instead of treaating it as data.

This change will treat the first column as data instead of index.

This fixes the failing test (test_azureml_data) that expects the first column to be part of the record set. Before this fix the test would get 10 records since it ignores the first column. After the fix it sees 15 records.

Test output:

test_awssagemaker_data (test_training_adapter.TestTrainingAdapter) ... Selected AWS SageMaker ML profile
Files in training directory: ['./static/data/data.csv']
ok
test_awssagemaker_folder (test_training_adapter.TestTrainingAdapter) ... Selected AWS SageMaker ML profile
/opt/ml/model/model.pkl
ok
test_awssagemaker_plugin (test_training_adapter.TestTrainingAdapter) ... Selected AWS SageMaker ML profile
ok
test_azureml_data (test_training_adapter.TestTrainingAdapter) ... Using Azure ML Sriracha profile
azure_mount_file=./static/data/data.csv
ok
test_azureml_folder (test_training_adapter.TestTrainingAdapter) ... Using Azure ML Sriracha profile
/Users/clarenceng/github/clarng/mlsriracha/tests/outputs/model/model.pkl
ok
test_azureml_plugin (test_training_adapter.TestTrainingAdapter) ... Using Azure ML Sriracha profile
ok

----------------------------------------------------------------------
Ran 6 tests in 0.008s